### PR TITLE
BB-48. Update Contact-Icons component. 

### DIFF
--- a/components/universal/contacts-icons.tsx
+++ b/components/universal/contacts-icons.tsx
@@ -21,7 +21,7 @@ const ContactsIcons = () => {
         });
       };
     const handleFacebook = () => {
-        Linking.openURL('fb://profile/100064281505779').catch(err => { // IRYNA! needs to be updated 
+        Linking.openURL('fb://profile/100064281505779').catch(err => { 
           Linking.openURL('https://www.facebook.com/churchSOL').catch(err => {
               Alert.alert('Error', 'Something went wrong.');
               console.error('An error occurred', err);


### PR DESCRIPTION
BB-48. Update Contact-Icons component. 
- All buttons works correct for me on IOS phone with Expo GO. 
- Updated Facebook button to go directly to SOL Church page instead of just Facebook app. 