### PR TITLE
[Fix] Dockerfile.dev change "0.0.0.0" to "lan"

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -26,4 +26,4 @@ ENV HOST=0.0.0.0 \
 EXPOSE 8081 19000 19001 19006
 
 # Start Expo in LAN mode; you can override with --tunnel or --web via compose
-CMD ["npm", "run", "start", "--", "--host", "0.0.0.0"]
+CMD ["npm", "run", "start", "--", "--host", "lan"]


### PR DESCRIPTION
Had issues with the wrong argument being passed to ```--host``` argument in the Dockerfile.dev. ```--host``` flag expects arguments ```lan|tunnel|localhost```. Changed argument "0.0.0.0" to "lan".