### PR TITLE
BB-95 Fix the headerbar

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -21,6 +21,7 @@ export default function TabLayout() {
       <Tabs.Screen
         name="index"
         options={{
+	  headerShown: false,
           title: 'SOL',
           tabBarIcon: ({ color }) => <SimpleLineIcons size={16} name="drop" color={color} />,
         }}
@@ -29,6 +30,7 @@ export default function TabLayout() {
         name="connect"
         
         options={{
+	  headerShown: false,
           title: 'Connect',
           tabBarIcon: ({ color }) => <SimpleLineIcons size={16} name="arrow-up-circle" color={color} />,
         }}
@@ -38,6 +40,7 @@ export default function TabLayout() {
         name="events"
         
         options={{
+	  headerShown: false,
           title: 'Events',
           tabBarIcon: ({ color }) => <FontAwesome size={16} name="calendar-o" color={color} />,
         }}
@@ -47,7 +50,7 @@ export default function TabLayout() {
         
         options={{
           title: 'Give',
-          
+          headerShown: false,
           tabBarIcon: ({ color }) => <FontAwesome6 size={16} name="hand-holding-heart" color={color} />,
         }}
       />
@@ -56,6 +59,7 @@ export default function TabLayout() {
         
         options={{
           title: 'Media',
+	  headerShown: false,
           tabBarIcon: ({ color }) => <MaterialCommunityIcons size={16} name="television-play" color={color} />,
         }}
       />
@@ -64,6 +68,7 @@ export default function TabLayout() {
         
         options={{
           title: 'Borrow',
+	  headerShown: false,
           tabBarIcon: ({ color }) => <SimpleLineIcons size={16} name="drawer" color={color} />,
         }}
       />

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -19,7 +19,6 @@ export default function Index() {
   });
   return (
     <ScrollView style = {styles.scrollContainer}>
-      <HeaderBar />
       <ImageSlider></ImageSlider>
       <View style={styles.container}>
         <DynamicEventSection></DynamicEventSection>

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,8 +1,13 @@
 import { Stack } from "expo-router";
+import HeaderBar from '../components/universal/header-bar';
 
 export default function RootLayout() {
-
-  return <Stack>
-      <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-    </Stack>;
+  return (
+    <>
+      <HeaderBar />
+      <Stack>
+        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+      </Stack>
+    </>
+  );
 }


### PR DESCRIPTION
Header bar is now the same across all tabs.

The header bar that was in index is replaced.

The title part of each header in every tab is now hidden.