### PR TITLE
Fix header and account page navigation

### DIFF
--- a/app/[auth]/account.tsx
+++ b/app/[auth]/account.tsx
@@ -347,7 +347,7 @@ export default function SettingsScreen() {
           }}
         >
           <Text style={[styles.modalTitle, { fontSize: 15 }]}>
-            Enter your email, and we'll send you a link to reset your password
+            Enter your email to get a password reset link
           </Text>
           <TextInput
             style={styles.input}
@@ -376,7 +376,7 @@ export default function SettingsScreen() {
               ]}
               onPress={handleForgotPWPress}
             >
-              <Text style={styles.actionBtnTxt}>Confirm</Text>
+              <Text style={styles.actionBtnTxt}>Send Email</Text>
             </Pressable>
           </View>
         </AuthModal>
@@ -509,7 +509,7 @@ const styles = StyleSheet.create({
   actionBtn: {
     height: 40,
     backgroundColor: "#bbb",
-    borderRadius: 150,
+    borderRadius: 7,
     width: "40%",
     maxWidth: 150,
     justifyContent: "center",

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,13 +1,18 @@
-import { Stack } from "expo-router";
+import { Slot, Stack } from "expo-router";
 import HeaderBar from '../components/universal/header-bar';
+import { initialWindowMetrics, SafeAreaProvider, SafeAreaView } from "react-native-safe-area-context";
+import { View } from "react-native";
 
 export default function RootLayout() {
   return (
-    <>
-      <HeaderBar />
-      <Stack>
-        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-      </Stack>
-    </>
+    <SafeAreaProvider initialMetrics={initialWindowMetrics}>
+      <SafeAreaView edges={['top', 'left', 'right']} style={{ backgroundColor: 'white' }}>
+        <HeaderBar />
+      </SafeAreaView>
+
+      <View style={{ flex: 1 }}>
+        <Stack screenOptions={{ headerShown: false }} />
+      </View>
+    </SafeAreaProvider>
   );
 }

--- a/components/universal/header-bar.tsx
+++ b/components/universal/header-bar.tsx
@@ -8,7 +8,7 @@ export default function HeaderBar() {
   };
   const handleLoginPress = () => {
     console.log('Login Image clicked!');
-    router.push("../../[auth]/account")
+    router.navigate("../../[auth]/account")
   };
 
   return (
@@ -30,12 +30,12 @@ export default function HeaderBar() {
             style={styles.icon}
           />
         </TouchableOpacity>
-        
+          
         <TouchableOpacity onPress={handleLoginPress}>
           <Image
             source={require('../../assets/images/login-button.png')}
             style={[styles.icon, { marginRight: 0 }]}
-          />
+            />
         </TouchableOpacity>
       </View>
     </View>


### PR DESCRIPTION
- Change navigation from `router.push` to `router.navigate` so tapping “login” won’t push duplicate account screens  
- Wrap HeaderBar in SafeAreaProvider / SafeAreaView so header respects safe areas on iOS, Android, and web  
- Remove previous RootLayout header and instead embed header inside safe area layout  